### PR TITLE
Added ToUpper() to partial name check.

### DIFF
--- a/Assets/SInput/Scripts/CommonGamepadBindings.cs
+++ b/Assets/SInput/Scripts/CommonGamepadBindings.cs
@@ -91,7 +91,7 @@ namespace SinputSystems {
 					//check for partial name matches with this gamepad slot
 					for (int i = 0; i < commonMappings.Count; i++) {
 						for (int k = 0; k < commonMappings[i].partialNames.Count; k++) {
-							if (!mappingMatch && gamepads[g].Contains(commonMappings[i].partialNames[k])) {
+							if (!mappingMatch && gamepads[g].Contains(commonMappings[i].partialNames[k].ToUpper())) {
 								mappingMatch = true;
 								mappingSlots[i].slots.Add(g);
 							}


### PR DESCRIPTION
String.Contains() is case-sensitive. Added ToUpper() to second partial name check to ensure String.Contains() finds them, regardless of case.